### PR TITLE
add padding to top of contact container

### DIFF
--- a/contactus.css
+++ b/contactus.css
@@ -17,7 +17,6 @@ body {
   background: var(--primary);
   font-family: "Poppins", sans-serif;
   font-size: 15px;
-  padding-top: 80px;
 }
 
 /* Navigation Section */
@@ -66,7 +65,7 @@ button {
 
 /* Contact Us Section */
 #contact-container {
-  padding: 40px 80px;
+  padding: 160px 40px 80px;
   width: 100%;
 
   display: flex;


### PR DESCRIPTION
I shifted the padding around to try and fix the issue with the contact form under the navbar. It appears fine in my Chrome browser. Please provide more details about your instance if it's still an issue.